### PR TITLE
Exculusion groups option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,21 @@ josef diff ./local_group_file.yml
 
 ### apply
 
-```
+```sh
 josef apply ./local_group_file.yml
+```
+
+Josef can config exculusion group mail addresses.example
+
+```yaml
+---
+exclued_groups:
+  - hoge@ml.example.com
+  - foo@example.com
+```
+
+```sh
+josef apply ./local_group_file.yml --exculude ./excluded_groups.yml
 ```
 
 ## Development

--- a/lib/josef/cli.rb
+++ b/lib/josef/cli.rb
@@ -7,6 +7,16 @@ module Josef
     include Josef::Remote
     include Josef::Diff
     class_option :dry_run, :type => :boolean, :default => false
+    class_option :exclude, :type => :string,  :default => nil
+
+    def invoke_command(command, *args)
+      prepare
+      super
+    end
+
+    def prepare
+      exculued_groups(options[:exclude])
+    end
 
     desc "dump", "dump google workspace group"
     def dump

--- a/lib/josef/cli.rb
+++ b/lib/josef/cli.rb
@@ -9,13 +9,15 @@ module Josef
     class_option :dry_run, :type => :boolean, :default => false
     class_option :exclude, :type => :string,  :default => nil
 
-    def invoke_command(command, *args)
-      prepare
-      super
-    end
+    no_commands do
+      def invoke_command(command, *args)
+        prepare
+        super
+      end
 
-    def prepare
-      exculued_groups(options[:exclude])
+      def prepare
+        exculued_groups(options[:exclude])
+      end
     end
 
     desc "dump", "dump google workspace group"

--- a/lib/josef/diff.rb
+++ b/lib/josef/diff.rb
@@ -29,7 +29,7 @@ module Josef
 
     def remote_diff(remote, local, mode = "apply")
       local.each do | local_group |
-        next if should_be_tareget?(local_group[:group_mail_address])
+        next unless should_be_tareget?(local_group)
 
         if be_create?(local_group)
           puts "#{local_group[:group_mail_address]} will be create:#{mode}"
@@ -54,7 +54,7 @@ module Josef
       end
 
       remote.each do | remote_group |
-        next if should_be_tareget?(local_group[:group_mail_address])
+        next unless should_be_tareget?(remote_group)
 
         if be_delete?(remote_group)
           puts "#{remote_group[:group_mail_address]} will be delete:#{mode}"

--- a/lib/josef/diff.rb
+++ b/lib/josef/diff.rb
@@ -4,6 +4,13 @@ module Josef
   module Diff
     include Josef::Remote
     include Josef::Local
+
+    def should_be_tareget?(local_group)
+      return false if exculued?(local_group[:group_mail_address])
+
+      true
+    end
+
     def changed?(local_group)
       remote_group = remote.find{|g| g[:group_mail_address] == local_group[:group_mail_address]}
       return false if local_group[:members].nil? || remote_group[:members].nil?
@@ -22,6 +29,8 @@ module Josef
 
     def remote_diff(remote, local, mode = "apply")
       local.each do | local_group |
+        next if should_be_tareget?(local_group[:group_mail_address])
+
         if be_create?(local_group)
           puts "#{local_group[:group_mail_address]} will be create:#{mode}"
           local_group[:members].each do | member |
@@ -45,6 +54,8 @@ module Josef
       end
 
       remote.each do | remote_group |
+        next if should_be_tareget?(local_group[:group_mail_address])
+
         if be_delete?(remote_group)
           puts "#{remote_group[:group_mail_address]} will be delete:#{mode}"
         end

--- a/lib/josef/local.rb
+++ b/lib/josef/local.rb
@@ -22,9 +22,9 @@ module Josef
     end
 
     def exculued_groups!(exculued_groups_file)
-      return [] exculued_groups_file.nil?
+      return [] if exculued_groups_file.nil?
 
-      YAML.load_file(exculued_groups_file).map{|h| h.deep_symbolize_keys}[:exculued_groups]
+      YAML.load_file(exculued_groups_file).symbolize_keys[:exculued_groups]
     end
   end
 end

--- a/lib/josef/local.rb
+++ b/lib/josef/local.rb
@@ -8,7 +8,23 @@ module Josef
     end
 
     def local!(local_file)
+      return [] if local_file.nil?
+
       YAML.load_file(local_file).map{|h| h.deep_symbolize_keys}
+    end
+
+    def exculued?(group_mail_address)
+      exculued_groups.include?(group_mail_address)
+    end
+
+    def exculued_groups(exculued_groups_file = nil)
+      @_exculued_groups ||= exculued_groups!(exculued_groups_file)
+    end
+
+    def exculued_groups!(exculued_groups_file)
+      return [] exculued_groups_file.nil?
+
+      YAML.load_file(exculued_groups_file).map{|h| h.deep_symbolize_keys}[:exculued_groups]
     end
   end
 end


### PR DESCRIPTION
Google Workspace can configure default groups. When create user, it join default groups.
If all Google Groups manage this tool, when create user, you must update yaml .
Add an option that you can use if you don't want to manage the groups you belong to by default.