### PR TITLE
Clear cache after create and delete

### DIFF
--- a/lib/josef/google_workspace/group.rb
+++ b/lib/josef/google_workspace/group.rb
@@ -29,15 +29,15 @@ module Josef
         group = ::Google::Apis::AdminDirectoryV1::Group.new(email: group_mail_address)
 
         client.insert_group(group)
+        @_groups = nil
       end
 
       def delete_group(group_mail_address)
         group = groups.find{|g| g.email == group_mail_address}
 
         client.delete_group(group.id)
+        @_groups = nil
       end
     end
   end
 end
-
-


### PR DESCRIPTION
Clear the cache after create or delete.
This is because the information you create or delete will not be reflected in the cache.